### PR TITLE
Rename staging property.

### DIFF
--- a/docs/integration-partner.md
+++ b/docs/integration-partner.md
@@ -36,7 +36,7 @@ const apiKey = process.env.API_KEY // Should be kept secret, can be regenerated
 Celsius({
     authMethod: AUTH_METHODS.API_KEY, // We are telling the SDK that we are authenticating using a combination of an API key and a Partner token
     partnerKey: partnerKey,
-    environment: ENVIRONMENT.staging // If not present, default is production.
+    environment: ENVIRONMENT.STAGING // If not present, default is production.
 }).then((celsius) => {
   // your code
 })

--- a/docs/omnibus-treasury.md
+++ b/docs/omnibus-treasury.md
@@ -50,7 +50,7 @@ const partnerKey = process.env.PARTNER_TOKEN // Should be kept secret
 Celsius({
     authMethod: AUTH_METHODS.API_KEY, // We are telling the SDK that we are authenticating using a combination of different user API keys and a Partner token
     partnerKey: partnerKey,
-    environment: ENVIRONMENT.staging // If not present, default is production.
+    environment: ENVIRONMENT.STAGING // If not present, default is production.
 }).then((celsius) => {
   // your code
 })

--- a/docs/segment-partner.md
+++ b/docs/segment-partner.md
@@ -40,7 +40,7 @@ const partnerKey = process.env.PARTNER_TOKEN // Should be kept secret
 Celsius({
     authMethod: AUTH_METHODS.USER_TOKEN, // We are telling the SDK that we are authenticating different users using user tokens.
     partnerKey: partnerKey,
-    environment: ENVIRONMENT.staging // If not present, default is production.
+    environment: ENVIRONMENT.STAGING // If not present, default is production.
 }).then((celsius) => {
   // your code
 })


### PR DESCRIPTION
Rename environment  `staging` property in documentation to uppercase. Using code from documentation with lowercase string was actually selecting production environment.