### PR TITLE
fix: getInterestRates() returns an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -304,7 +304,7 @@ declare module 'celsius-sdk' {
             coin: string;
             rate: string;
             currency: Currency;
-        }
+        }[]
     }
 
     interface Currency {


### PR DESCRIPTION
the `getInterestRates` end point returns an array in `interestRates`. This PR makes a small change to the `InterestRates` interface in `index.d.ts` to reflect this.