### PR TITLE
Fix CelsiusBalanceSummaryResponse typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare module 'celsius-sdk' {
     interface CelsiusBalanceSummaryResponse {
         /** Contains user's balance per coin. **/
         balance: {
-            [key: string]: number
+            [key: string]: string
         }
     }
 


### PR DESCRIPTION
Fixes the typing for `interface CelsiusBalanceSummaryResponse`

Here is the sample response of `GET /wallet/balance/` endpoint
```
{
    "balance": {
        "eth": "0",
        "btc": "0",
        "dash": "0",
        "bch": "0",
        "bsv": "0",
        "ltc": "0",
        "zec": "0",
        "btg": "0",
        "xrp": "0",
        "xlm": "0",
        "omg": "0",
        "tusd": "0",
        "gusd": "0",
        "pax": "0",
        "paxg": "0",
        "usdc": "0",
        "usdc-polygon": "0",
        "dai": "0",
        "mcdai": "0",
        "mcdai-polygon": "0",
        "cel": "0",
        "zrx": "0",
        "orbs": "0",
        "usdt erc20": "0",
        "usdt-polygon": "0",
        "tgbp": "0",
        "taud": "0",
        "thkd": "0",
        "tcad": "0",
        "eos": "0",
        "sga": "0",
        "sgr": "0",
        "xaut": "0",
        "etc": "0",
        "bat": "0",
        "busd": "0",
        "knc": "0",
        "link": "0",
        "lpt": "0",
        "matic": "0",
        "snx": "0",
        "uma": "0",
        "uni": "0",
        "mana": "0",
        "comp": "0",
        "spark": "0",
        "steth": "0",
        "aave": "0",
        "aave-polygon": "0",
        "bnt": "0",
        "dot": "0",
        "wdgld": "0",
        "zusd": "0",
        "bnb": "0",
        "luna": "0",
        "ada": "0",
        "cxada-polygon": "0",
        "cxdoge-polygon": "0",
        "cxeth-polygon": "0",
        "cel-polygon": "0",
        "sushi": "0",
        "sushi-polygon": "0",
        "1inch": "0",
        "xtz": "0",
        "wbtc": "0",
        "avax": "0",
        "matic-polygon": "0",
        "doge": "0",
        "sol": "0",
        "sgb": "0"
    }
}
```